### PR TITLE
Clip steps maximum value

### DIFF
--- a/run.c
+++ b/run.c
@@ -839,7 +839,7 @@ int main(int argc, char *argv[]) {
     // build the Transformer via the model .bin file
     Transformer transformer;
     build_transformer(&transformer, checkpoint_path);
-    if (steps == 0) steps = transformer.config.seq_len; // ovrerride to ~max length
+    if (steps == 0 || steps > transformer.config.seq_len) steps = transformer.config.seq_len; // ovrerride to ~max length
 
     // build the Tokenizer via the tokenizer .bin file
     Tokenizer tokenizer;


### PR DESCRIPTION
@karpathy This PR limits the max value of steps to not be more than the model's seq_len for completeness. It will segfault in the forward pass when pos goes beyond seq_len otherwise.